### PR TITLE
Tweak spelling of Bioconductor

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ install.packages("pkgcache")
 ## Metadata cache
 
 `cran_list()` lists all packages in the metadata cache. It includes
-BioConductor package, and all versions (i.e. both binary and source)
+Bioconductor package, and all versions (i.e. both binary and source)
 of the packages for the current platform and R version.
 
 ```{r}


### PR DESCRIPTION
Super minor, but when spelled out fully all the Bioconductor materials I have seen use a lowercase C.

The only time a uppercase C is used is when abbreviating it, e.g. `BioC`.