### PR TITLE
Trying to fix failing test with comparing diff times

### DIFF
--- a/tests/testthat/test-cran-metadata.R
+++ b/tests/testthat/test-cran-metadata.R
@@ -22,9 +22,10 @@ test_that("what if cran.r-pkg.org is down?", {
 
     ## This is slow on older R versions
     limit <- if (getRversion() < "3.4") 30 else 20
+    duration <- difftime(toc, tic, units = "secs")
     expect_true(
-      toc - tic < as.difftime(limit, units = "secs"),
-      info = toc - tic
+      duration < as.difftime(limit, units = "secs"),
+      info = format(toc - tic)
     )
   })
 })


### PR DESCRIPTION
This seems to work.... is it possible that difftime objects do not have comparison methods? 