### PR TITLE
`http_delete()` now gets default curl options.

### DIFF
--- a/R/aaa-async.R
+++ b/R/aaa-async.R
@@ -2886,6 +2886,7 @@ http_post <- mark_as_async(http_post)
 http_delete <- function(url, headers = character(), file = NULL,
                         options = list()) {
   url; headers; options;
+  options <- get_default_curl_options(options)
 
   make_deferred_http(
     function() {


### PR DESCRIPTION
I was just browsing the source code and came across this. It seems that right now `http_delete()` doesn't use `get_default_curl_options()` like the other `http_*` functions do. Maybe there's a reason for that I'm not aware of, but I figure it was worth proposing the change in case.