### PR TITLE
Add support for sourcing repository credentials from the keyring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Suggests:
     fs,
     keyring,
     mockery,
-    openssl,
     pillar,
     pingr,
     rprojroot,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     jsonlite,
     processx (>= 3.3.0.9001),
     R6,
-    rlang,
     tools,
     utils
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     jsonlite,
     processx (>= 3.3.0.9001),
     R6,
+    rlang,
     tools,
     utils
 Suggests:
@@ -28,7 +29,9 @@ Suggests:
     debugme,
     desc,
     fs,
+    keyring,
     mockery,
+    openssl,
     pillar,
     pingr,
     rprojroot,

--- a/R/archive.R
+++ b/R/archive.R
@@ -372,7 +372,10 @@ cac__update_replica <- function(self, private) {
   # download_if_newer(). If the response is 304, then we'll ignore the file.
   file.create(tmp)
 
-  download_if_newer(url, tmp, etag_file, error_on_status = FALSE)$
+  key <- random_key()
+  async_constant()$
+    then(function() start_auth_cache(key))$
+    then(function() download_if_newer(url, tmp, etag_file, error_on_status = FALSE))$
     then(function(dl) {
       if (dl$response$status_code >= 300 && dl$response$status_code != 304) {
         stop("Failed to update package archive metadata")
@@ -385,7 +388,10 @@ cac__update_replica <- function(self, private) {
       }
       dl
     })$
-    finally(function() unlink(tmp))
+    finally(function() {
+      unlink(tmp)
+      clear_auth_cache(key)
+    })
 }
 
 cac__convert_archive_file <- function(self, private, raw, out) {

--- a/R/async-http.R
+++ b/R/async-http.R
@@ -356,7 +356,7 @@ download_one_of <- function(urls, destfile, etag_file = NULL,
 }
 
 download_files <- function(data, error_on_status = TRUE,
-                           options = list(), ...) {
+                           options = list(), headers = NULL, ...) {
 
   if (any(dup <- duplicated(data$path))) {
     stop("Duplicate target paths in download_files: ",
@@ -371,6 +371,7 @@ download_files <- function(data, error_on_status = TRUE,
     row <- data[idx, ]
     dx <- download_if_newer(
       row$url, row$path, row$etag,
+      headers = c(headers, row$headers[[1L]]),
       on_progress = prog_cb,
       error_on_status = error_on_status,
       options = options, ...
@@ -380,6 +381,7 @@ download_files <- function(data, error_on_status = TRUE,
       dx <- dx$catch(error = function(err) {
         download_if_newer(
           row$fallback_url, row$path, row$etag,
+          headers = c(headers, row$headers[[1L]]),
           error_on_status = error_on_status,
           options = options, ...
         )

--- a/R/async-http.R
+++ b/R/async-http.R
@@ -122,7 +122,7 @@ download_file <- function(url, destfile, etag_file = NULL,
 
   headers <- add_auth_header(url, headers)
 
-  http_get(url, file = tmp_destfile, options = options, ...)$
+  http_get(url, file = tmp_destfile, options = options, headers = headers, ...)$
     then(http_stop_for_status)$
     then(function(resp) {
       "!DEBUG downloaded `url`"

--- a/R/auth.R
+++ b/R/auth.R
@@ -51,7 +51,7 @@ repo_auth_headers <- function(url, allow_prompt = interactive()) {
   }
 
   auth <- paste(creds$username, pwd, sep = ":")
-  c("Authorization" = paste("Basic", openssl::base64_encode(auth)))
+  c("Authorization" = paste("Basic", processx::base64_encode(auth)))
 }
 
 extract_basic_auth_credentials <- function(url) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -60,11 +60,20 @@ repo_auth_headers <- function(
   res
 }
 
-clear_auth_cache <- function() {
-  rm(
-    list = ls(pkgenv$credentials, all.names = TRUE),
-    envir = pkgenv$credentials
-  )
+clear_auth_cache <- function(key = NULL) {
+  if (is.null(key) ||
+    identical(pkgenv$credentials[[".exit_handler"]], key)) {
+    rm(
+      list = ls(pkgenv$credentials, all.names = TRUE),
+      envir = pkgenv$credentials
+    )
+  }
+}
+
+start_auth_cache <- function(key) {
+  if (! ".exit_handler" %in% names(pkgenv$credentials)) {
+    assign(".exit_handler", key, envir = pkgenv$credentials)
+  }
 }
 
 base64_encode <- function(x) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -3,6 +3,11 @@
 repo_auth_headers <- function(
   url, allow_prompt = interactive(), use_cache = TRUE, set_cache = TRUE) {
 
+  # shortcut to speed up the common case of no credentials
+  if (!grepl("@", url)) {
+    return(NULL)
+  }
+
   creds <- extract_basic_auth_credentials(url)
   if (length(creds$password) > 0 && nchar(creds$password) != 0) {
     # The URL already contains a password. This is pretty poor practice, maybe

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,0 +1,91 @@
+# Returns a set of HTTP headers for the given URL if (1) it belongs to a
+# package repository; and (2) has credentials stored in the keyring.
+repo_auth_headers <- function(url, allow_prompt = interactive()) {
+  if (!grepl("/(src|bin)/", url)) {
+    # Not a package or package index URL.
+    return(NULL)
+  }
+  if (!rlang::is_installed("keyring")) {
+    return(NULL)
+  }
+  creds <- extract_basic_auth_credentials(url)
+  if (!is.null(creds$password)) {
+    # The URL already contains a password. This is pretty poor practice, maybe
+    # we should issue a warning pointing users to the keyring package instead.
+    return(NULL)
+  }
+  if (is.null(creds$username)) {
+    # No username to key the lookup in the keyring with.
+    return(NULL)
+  }
+
+  # In non-interactive contexts, force the use of the environment variable
+  # backend so that we never hang but can still support CI setups.
+  backend <- keyring::backend_env
+  if (allow_prompt) {
+    backend <- keyring::default_backend()
+  }
+  kb <- backend$new()
+
+  # Use the repo URL without the username as the keyring "service".
+  svc <- extract_repo_url(url)
+  pwd <- NULL
+  tryCatch(
+    {
+      pwd <- kb$get(svc, creds$username)
+    },
+    error = function(e) NULL
+  )
+
+  # Check whether we have one for the hostname as well.
+  svc <- extract_hostname(url)
+  tryCatch(
+    {
+      pwd <- kb$get(svc, creds$username)
+    },
+    error = function(e) NULL
+  )
+
+  if (is.null(pwd)) {
+    return(NULL)
+  }
+
+  auth <- paste(creds$username, pwd, sep = ":")
+  c("Authorization" = paste("Basic", openssl::base64_encode(auth)))
+}
+
+extract_basic_auth_credentials <- function(url) {
+  pattern <- "^https?://(?:([^:@/]+)(?::([^@/]+))?@)?.*$"
+  if (!grepl(pattern, url, perl = TRUE)) {
+    cli::cli_abort("Unrecognized URL format: {.url {url}}.", .internal = TRUE)
+  }
+  username <- sub(pattern, "\\1", url, perl = TRUE)
+  if (!nchar(username)) {
+    username <- NULL
+  }
+  password <- sub(pattern, "\\2", url, perl = TRUE)
+  if (!nchar(password)) {
+    password <- NULL
+  }
+  list(username = username, password = password)
+}
+
+extract_repo_url <- function(url) {
+  url <- sub(
+    "^(https?://)(?:[^:@/]+(?::[^@/]+)?@)?(.*)(/(src|bin)/)(.*)$",
+    "\\1\\2",
+    url,
+    perl = TRUE
+  )
+  # Lop off any /__linux__/ subdirectories, too.
+  sub("^(.*)/__linux__/[^/]+(/.*)$", "\\1\\2", url, perl = TRUE)
+}
+
+extract_hostname <- function(url) {
+  sub(
+    "^(https?://)(?:[^:@/]+(?::[^@/]+)?@)?([^/]+)(.*)",
+    "\\1\\2",
+    url,
+    perl = TRUE
+  )
+}

--- a/R/auth.R
+++ b/R/auth.R
@@ -5,7 +5,7 @@ repo_auth_headers <- function(url, allow_prompt = interactive()) {
     # Not a package or package index URL.
     return(NULL)
   }
-  if (!rlang::is_installed("keyring")) {
+  if (!requireNamespace("keyring", quietly = TRUE)) {
     return(NULL)
   }
   creds <- extract_basic_auth_credentials(url)

--- a/R/metadata-cache.R
+++ b/R/metadata-cache.R
@@ -752,7 +752,11 @@ cmc__update_replica_pkgs <- function(self, private) {
     mayfail = TRUE
   )
 
-  download_files(dls)$
+  key <- random_key()
+  async_constant()$
+    finally(function() clear_auth_cache(key))$
+    then(function() start_auth_cache(key))$
+    then(function() download_files(dls))$
     then(function(result) {
       missing_pkgs_note(pkgs, result)
       load_bioc_sysreqs()

--- a/R/metadata-cache.R
+++ b/R/metadata-cache.R
@@ -754,14 +754,14 @@ cmc__update_replica_pkgs <- function(self, private) {
 
   key <- random_key()
   async_constant()$
-    finally(function() clear_auth_cache(key))$
     then(function() start_auth_cache(key))$
     then(function() download_files(dls))$
     then(function(result) {
       missing_pkgs_note(pkgs, result)
       load_bioc_sysreqs()
       result
-    })
+    })$
+    finally(function() clear_auth_cache(key))
 }
 
 # E.g. "R 4.1 macos packages are missing from CRAN and Bioconductor"

--- a/R/metadata-cache.R
+++ b/R/metadata-cache.R
@@ -737,12 +737,17 @@ cmc__update_replica_pkgs <- function(self, private) {
 
   meta <- !is.na(pkgs$meta_url)
   bin <- !is.na(pkgs$bin_url)
-  dls <- data.frame(
-    stringsAsFactors = FALSE,
+  dls <- data_frame(
     url = c(pkgs$url, pkgs$meta_url[meta], pkgs$bin_url[bin], bsq_url),
     fallback_url = c(pkgs$fallback_url, rep(NA_character_, sum(meta) + sum(bin)), NA_character_),
     path = c(pkgs$path, pkgs$meta_path[meta], pkgs$bin_path[bin], bsq_path),
     etag = c(pkgs$etag, pkgs$meta_etag[meta], pkgs$bin_etag[bin], bsq_etag),
+    headers = c(
+      lapply(pkgs$url, repo_auth_headers),
+      vector("list", length = sum(meta)),
+      lapply(pkgs$bin_url[bin], repo_auth_headers),
+      vector("list", length = 1)
+    ),
     timeout = c(rep(c(200, 100), c(nrow(pkgs), sum(meta) + sum(bin))), 5),
     mayfail = TRUE
   )

--- a/R/metadata-cache.R
+++ b/R/metadata-cache.R
@@ -743,9 +743,9 @@ cmc__update_replica_pkgs <- function(self, private) {
     path = c(pkgs$path, pkgs$meta_path[meta], pkgs$bin_path[bin], bsq_path),
     etag = c(pkgs$etag, pkgs$meta_etag[meta], pkgs$bin_etag[bin], bsq_etag),
     headers = c(
-      lapply(pkgs$url, repo_auth_headers),
+      lapply(pkgs$url, function(x) repo_auth_headers(x)$headers),
       vector("list", length = sum(meta)),
-      lapply(pkgs$bin_url[bin], repo_auth_headers),
+      lapply(pkgs$bin_url[bin], function(x) repo_auth_headers(x)$headers),
       vector("list", length = 1)
     ),
     timeout = c(rep(c(200, 100), c(nrow(pkgs), sum(meta) + sum(bin))), 5),

--- a/R/onload.R
+++ b/R/onload.R
@@ -170,6 +170,8 @@ pkgenv$ppm_r_versions_cached <- c("3.6", "4.0", "4.1", "4.2", "4.3")
 
 pkgenv$package_versions <- new.env(parent = emptyenv())
 
+pkgenv$credentials <- new.env(parent = emptyenv())
+
 onload_pkgcache <- function(libname, pkgname) {
   if (Sys.getenv("PKGCACHE_NO_PILLAR") == "") {
     requireNamespace("pillar", quietly = TRUE)

--- a/R/package-cache.R
+++ b/R/package-cache.R
@@ -181,7 +181,7 @@ package_cache <- R6Class(
       self; private; url; path; list(...); .list; on_progress; http_headers
       target <- tempfile()
       download_file(url, target, on_progress = on_progress,
-                    headers = http_headers)$
+                    headers = c(http_headers, repo_auth_headers(url)))$
         then(function(res) {
           headers <- curl::parse_headers(res$response$headers, multiple = TRUE)
           self$add(target, path, url = url, etag = res$etag, ...,
@@ -209,7 +209,7 @@ package_cache <- R6Class(
         then(function(res) {
           if (! nrow(res)) {
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = http_headers)$
+                            headers = c(http_headers, repo_auth_headers(urls[1])))$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -249,7 +249,7 @@ package_cache <- R6Class(
           if (! nrow(res)) {
             ## Not in the cache, download and add it
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = http_headers)$
+                            headers = c(http_headers, repo_auth_headers(urls[1])))$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -263,7 +263,7 @@ package_cache <- R6Class(
             cat(res$etag, file = etag <- tempfile())
             download_one_of(urls, target, etag_file = etag,
                             on_progress = on_progress,
-                            headers = http_headers)$
+                            headers = c(http_headers, repo_auth_headers(urls[1])))$
               then(function(d) {
                 if (d$response$status_code != 304) {
                   ## No current, update it

--- a/R/package-cache.R
+++ b/R/package-cache.R
@@ -181,7 +181,7 @@ package_cache <- R6Class(
       self; private; url; path; list(...); .list; on_progress; http_headers
       target <- tempfile()
       download_file(url, target, on_progress = on_progress,
-                    headers = c(http_headers, repo_auth_headers(url)))$
+                    headers = c(http_headers, repo_auth_headers(url)$headers))$
         then(function(res) {
           headers <- curl::parse_headers(res$response$headers, multiple = TRUE)
           self$add(target, path, url = url, etag = res$etag, ...,
@@ -209,7 +209,7 @@ package_cache <- R6Class(
         then(function(res) {
           if (! nrow(res)) {
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])))$
+                            headers = c(http_headers, repo_auth_headers(urls[1])$headers))$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -249,7 +249,7 @@ package_cache <- R6Class(
           if (! nrow(res)) {
             ## Not in the cache, download and add it
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])))$
+                            headers = c(http_headers, repo_auth_headers(urls[1])$headers))$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -263,7 +263,7 @@ package_cache <- R6Class(
             cat(res$etag, file = etag <- tempfile())
             download_one_of(urls, target, etag_file = etag,
                             on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])))$
+                            headers = c(http_headers, repo_auth_headers(urls[1])$headers))$
               then(function(d) {
                 if (d$response$status_code != 304) {
                   ## No current, update it

--- a/R/package-cache.R
+++ b/R/package-cache.R
@@ -177,13 +177,11 @@ package_cache <- R6Class(
     ## Just download a file from an url and add it
     ## Returns a deferred value
     async_add_url = function(url, path, ..., .list = NULL,
-                             on_progress = NULL, http_headers = NULL,
-                            auth_domain = NULL) {
+                             on_progress = NULL, http_headers = NULL) {
       self; private; url; path; list(...); .list; on_progress; http_headers
       target <- tempfile()
       download_file(url, target, on_progress = on_progress,
-                    headers = c(http_headers, repo_auth_headers(url)$headers),
-                    auth_domain = NULL)$
+                    headers = http_headers)$
         then(function(res) {
           headers <- curl::parse_headers(res$response$headers, multiple = TRUE)
           self$add(target, path, url = url, etag = res$etag, ...,
@@ -202,7 +200,7 @@ package_cache <- R6Class(
     ## If the file is not in the cache, then download it and add it.
     async_copy_or_add = function(target, urls, path, sha256 = NULL, ...,
                                  .list = NULL, on_progress = NULL,
-                                 http_headers = NULL, auth_domains = NULL) {
+                                 http_headers = NULL) {
       self; private; target; urls; path; sha256; list(...); .list
       on_progress; http_headers
       etag <- tempfile()
@@ -211,8 +209,7 @@ package_cache <- R6Class(
         then(function(res) {
           if (! nrow(res)) {
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])$headers),
-                            auth_domains = auth_domains)$
+                            headers = http_headers)$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -242,7 +239,7 @@ package_cache <- R6Class(
     ## in the cache as well
     async_update_or_add = function(target, urls, path, sha256 = NULL, ...,
                                    .list = NULL, on_progress = NULL,
-                                   http_headers = NULL, auth_domains = NULL) {
+                                   http_headers = NULL) {
       self; private; target; urls; path; sha256; list(...); .list;
       on_progress; http_headers
       async_constant()$
@@ -252,8 +249,7 @@ package_cache <- R6Class(
           if (! nrow(res)) {
             ## Not in the cache, download and add it
             download_one_of(urls, target, on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])$headers),
-                            auth_domains = auth_domains)$
+                            headers = http_headers)$
               then(function(d) {
                 headers <- curl::parse_headers(d$response$headers, multiple = TRUE)
                 sha256 <- shasum256(target)
@@ -267,8 +263,7 @@ package_cache <- R6Class(
             cat(res$etag, file = etag <- tempfile())
             download_one_of(urls, target, etag_file = etag,
                             on_progress = on_progress,
-                            headers = c(http_headers, repo_auth_headers(urls[1])$headers),
-                            auth_domains = auth_domains)$
+                            headers = http_headers)$
               then(function(d) {
                 if (d$response$status_code != 304) {
                   ## No current, update it

--- a/R/parse-url.R
+++ b/R/parse-url.R
@@ -3,7 +3,7 @@ parse_url <- function(url) {
   re_url <- paste0(
     "^(?<protocol>[a-zA-Z0-9]+)://",
     "(?:(?<username>[^@/:]+)(?::(?<password>[^@/]+))?@)?",
-    "(?<host>[^/]+)",
+    "(?<host>[^/]*)",
     "(?<path>.*)$"            # don't worry about query params here...
   )
 
@@ -48,4 +48,3 @@ re_match <- function(text, pattern, perl = TRUE, ...) {
   names(res) <- c(attr(match, "capture.names"), ".text", ".match")
   res
 }
-

--- a/R/ppm.R
+++ b/R/ppm.R
@@ -202,8 +202,14 @@ async_get_ppm_status <- function(forget = FALSE, distribution = NULL,
       })
   }
 
-  def$
-    finally(function() unlink(tmp2))$
+  key <- random_key()
+  async_constant()$
+    then(function() start_auth_cache(key))$
+    then(function() def)$
+    finally(function() {
+      clear_auth_cache(key)
+      unlink(tmp2)
+    })$
     then(function() {
       list(
         distros = pkgenv$ppm_distros,

--- a/R/utils.R
+++ b/R/utils.R
@@ -226,3 +226,7 @@ is_rcmd_check <- function() {
     Sys.getenv("_R_CHECK_PACKAGE_NAME_", "") != ""
   }
 }
+
+random_key <- function() {
+  basename(tempfile())
+}

--- a/tests/testthat/_snaps/auth.md
+++ b/tests/testthat/_snaps/auth.md
@@ -144,12 +144,12 @@
     Code
       cmc$update()
     Message
-      [K
-      v Updated metadata database: <size> <unit> in <num> files.[K
+      
+      v Updated metadata database: <size> <unit> in <num> files.
       
       i source packages are missing from CRAN: Unauthorized (HTTP 401).
-      i Updating metadata database[K
-      v Updating metadata database ... done[K
+      i Updating metadata database
+      v Updating metadata database ... done
       
     Output
       $pkgs
@@ -171,11 +171,11 @@
     Code
       cmc$update()
     Message
-      [K
-      v Updated metadata database: <size> B in 1 file.[K
       
-      i Updating metadata database[K
-      v Updating metadata database ... done[K
+      v Updated metadata database: <size> B in 1 file.
+      
+      i Updating metadata database
+      v Updating metadata database ... done
       
     Output
       $pkgs

--- a/tests/testthat/_snaps/auth.md
+++ b/tests/testthat/_snaps/auth.md
@@ -139,6 +139,64 @@
       Error in `stop()`:
       ! Unauthorized (HTTP 401).
 
+# repo with basic auth
+
+    Code
+      cmc$update()
+    Message
+      [K
+      v Updated metadata database: <size> <unit> in <num> files.[K
+      
+      i source packages are missing from CRAN: Unauthorized (HTTP 401).
+      i Updating metadata database[K
+      v Updating metadata database ... done[K
+      
+    Output
+      $pkgs
+      # A data frame: 0 x 20
+      # i 20 variables: repodir <chr>, rversion <chr>, platform <chr>,
+      #   needscompilation <chr>, priority <chr>, package <chr>, version <chr>,
+      #   ref <chr>, type <chr>, direct <lgl>, status <chr>, target <chr>,
+      #   mirror <chr>, sources <list>, filesize <lgl>, sha256 <chr>, sysreqs <lgl>,
+      #   built <chr>, published <dttm>, deps <list>
+      
+      $deps
+      # A data frame: 0 x 7
+      # i 7 variables: upstream <chr>, idx <int>, ref <chr>, type <chr>,
+      #   package <chr>, version <chr>, op <chr>
+      
+
+---
+
+    Code
+      cmc$update()
+    Message
+      [K
+      v Updated metadata database: <size> B in 1 file.[K
+      
+      i Updating metadata database[K
+      v Updating metadata database ... done[K
+      
+    Output
+      $pkgs
+      # A data frame: 3 x 22
+        package version md5sum      needscompilation depends repodir rversion platform
+        <chr>   <chr>   <chr>       <chr>            <chr>   <chr>   <chr>    <chr>   
+      1 pkg1    1.0.0   <md5sum> no               <NA>    src/co~ *        source  
+      2 pkg2    1.0.0   <md5sum> no               pkg1    src/co~ *        source  
+      3 pkg3    1.0.0   <md5sum> no               pkg2    src/co~ *        source  
+      # i 14 more variables: priority <chr>, ref <chr>, type <chr>, direct <lgl>,
+      #   status <chr>, target <chr>, mirror <chr>, sources <list>, filesize <int>,
+      #   sha256 <chr>, sysreqs <chr>, built <chr>, published <dttm>, deps <list>
+      
+      $deps
+      # A data frame: 2 x 7
+        upstream   idx ref   type    package op    version
+        <chr>    <int> <chr> <chr>   <chr>   <chr> <chr>  
+      1 pkg2         2 pkg1  depends pkg1    ""    ""     
+      2 pkg3         3 pkg2  depends pkg2    ""    ""     
+      
+
 # basic auth credentials can be extracted from various URL formats
 
     Code

--- a/tests/testthat/_snaps/auth.md
+++ b/tests/testthat/_snaps/auth.md
@@ -1,0 +1,154 @@
+# looking up auth headers for repositories works as expected
+
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+        allow_prompt = FALSE, use_cache = FALSE, set_cache = FALSE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal/cran/latest"
+      
+
+---
+
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+        allow_prompt = FALSE, use_cache = FALSE, set_cache = FALSE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal/cran/latest"
+      
+
+# caching
+
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+        allow_prompt = FALSE, use_cache = TRUE, set_cache = TRUE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal/cran/latest"
+      
+    Code
+      pkgenv$credentials[["https://ppm.internal/cran/latest"]]
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal/cran/latest"
+      
+
+---
+
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+        allow_prompt = FALSE, use_cache = TRUE, set_cache = TRUE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal"
+      
+    Code
+      pkgenv$credentials[["https://ppm.internal"]]
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal"
+      
+
+# basic auth credentials can be extracted from various URL formats
+
+    Code
+      extract_basic_auth_credentials("https://user.name:pass-word123@example.com")
+    Output
+      $hosturl
+      [1] "https://example.com"
+      
+      $hostuserurl
+      [1] "https://user.name@example.com"
+      
+      $repourl
+      [1] "https://example.com"
+      
+      $repouserurl
+      [1] "https://user.name@example.com"
+      
+      $username
+      [1] "user.name"
+      
+      $password
+      [1] "pass-word123"
+      
+    Code
+      extract_basic_auth_credentials("http://user@example.com")
+    Output
+      $hosturl
+      [1] "http://example.com"
+      
+      $hostuserurl
+      [1] "http://user@example.com"
+      
+      $repourl
+      [1] "http://example.com"
+      
+      $repouserurl
+      [1] "http://user@example.com"
+      
+      $username
+      [1] "user"
+      
+      $password
+      [1] ""
+      
+    Code
+      extract_basic_auth_credentials("https://example.com")
+    Output
+      $hosturl
+      [1] "https://example.com"
+      
+      $hostuserurl
+      [1] "https://example.com"
+      
+      $repourl
+      [1] "https://example.com"
+      
+      $repouserurl
+      [1] "https://example.com"
+      
+      $username
+      [1] ""
+      
+      $password
+      [1] ""
+      
+
+---
+
+    Code
+      extract_basic_auth_credentials("notaurl")
+    Condition
+      Error:
+      ! Unrecognized URL format: `notaurl`.
+

--- a/tests/testthat/_snaps/auth.md
+++ b/tests/testthat/_snaps/auth.md
@@ -33,7 +33,19 @@
     Code
       repo_auth_headers(
         "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
-        allow_prompt = FALSE, use_cache = TRUE, set_cache = TRUE)
+        allow_prompt = FALSE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal/cran/latest"
+      
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+        allow_prompt = FALSE)
     Output
       $headers
                      Authorization 
@@ -58,7 +70,19 @@
     Code
       repo_auth_headers(
         "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
-        allow_prompt = FALSE, use_cache = TRUE, set_cache = TRUE)
+        allow_prompt = FALSE)
+    Output
+      $headers
+                     Authorization 
+      "Basic dXNlcm5hbWU6dG9rZW4=" 
+      
+      $auth_domain
+      [1] "https://ppm.internal"
+      
+    Code
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+        allow_prompt = FALSE)
     Output
       $headers
                      Authorization 
@@ -77,6 +101,43 @@
       $auth_domain
       [1] "https://ppm.internal"
       
+
+# http requests with auth
+
+    Code
+      readLines(tmp, warn = FALSE)
+    Output
+      [1] "{\"authenticated\":true,\"user\":\"username\"}"
+
+---
+
+    Code
+      readLines(tmp, warn = FALSE)
+    Output
+      [1] "{\"authenticated\":true,\"user\":\"username\"}"
+
+---
+
+    Code
+      readLines(tmp2, warn = FALSE)
+    Output
+      [1] "{\"authenticated\":true,\"user\":\"username\"}"
+
+---
+
+    Code
+      synchronise(download_file(url2, tmp3))
+    Condition
+      Error in `stop()`:
+      ! Unauthorized (HTTP 401).
+
+---
+
+    Code
+      synchronise(download_if_newer(url2, tmp3))
+    Condition
+      Error in `stop()`:
+      ! Unauthorized (HTTP 401).
 
 # basic auth credentials can be extracted from various URL formats
 

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -1,0 +1,110 @@
+fake <- local({
+  fake_through_tree <- function(tree, what, how) {
+    for (d in tree) {
+      for (parent in d) {
+        parent_env <- parent[["parent_env"]]
+        func_dict <- parent[["funcs"]]
+        for (func_name in ls(func_dict, all.names = TRUE)) {
+          func <- func_dict[[func_name]]
+          func_env <- new.env(parent = environment(func))
+
+          what <- override_seperators(what, func_env)
+          where_name <- override_seperators(func_name, parent_env)
+
+          if (!is.function(how)) {
+            assign(what, function(...) how, func_env)
+          } else {
+            assign(what, how, func_env)
+          }
+
+          environment(func) <- func_env
+          locked <- exists(where_name, parent_env, inherits = FALSE) &&
+            bindingIsLocked(where_name, parent_env)
+          if (locked) {
+            baseenv()$unlockBinding(where_name, parent_env)
+          }
+          assign(where_name, func, parent_env)
+          if (locked) {
+            lockBinding(where_name, parent_env)
+          }
+        }
+      }
+    }
+  }
+
+  override_seperators <- function(name, env) {
+    mangled_name <- NULL
+    for (sep in c("::", "$")) {
+      if (grepl(sep, name, fixed = TRUE)) {
+        elements <- strsplit(name, sep, fixed = TRUE)
+        mangled_name <- paste(
+          elements[[1L]][1L],
+          elements[[1L]][2L],
+          sep = "XXX"
+        )
+
+        stub_list <- c(mangled_name)
+        if ("stub_list" %in% names(attributes(get(sep, env)))) {
+          stub_list <- c(stub_list, attributes(get(sep, env))[["stub_list"]])
+        }
+
+        create_new_name <- create_create_new_name_function(
+          stub_list,
+          env,
+          sep
+        )
+        assign(sep, create_new_name, env)
+      }
+    }
+    mangled_name %||% name
+  }
+
+  backtick <- function(x) {
+    encodeString(x, quote = "`", na.encode = FALSE)
+  }
+
+  create_create_new_name_function <- function(stub_list, env, sep) {
+    force(stub_list)
+    force(env)
+    force(sep)
+
+    create_new_name <- function(pkg, func) {
+      pkg_name <- deparse(substitute(pkg))
+      func_name <- deparse(substitute(func))
+      for (stub in stub_list) {
+        if (paste(pkg_name, func_name, sep = "XXX") == stub) {
+          return(eval(parse(text = backtick(stub)), env))
+        }
+      }
+
+      # used to avoid recursively calling the replacement function
+      eval_env <- new.env(parent = parent.frame())
+      assign(sep, eval(parse(text = paste0("`", sep, "`"))), eval_env)
+
+      code <- paste(pkg_name, backtick(func_name), sep = sep)
+      return(eval(parse(text = code), eval_env))
+    }
+    attributes(create_new_name) <- list(stub_list = stub_list)
+    create_new_name
+  }
+
+  build_function_tree <- function(test_env, where, where_name) {
+    func_dict <- new.env()
+    func_dict[[where_name]] <- where
+    tree <- list(
+      list(
+        list(parent_env = test_env, funcs = func_dict)
+      )
+    )
+
+    tree
+  }
+
+  fake <- function(where, what, how) {
+    where_name <- deparse(substitute(where))
+    stopifnot(is.character(what), length(what) == 1)
+    test_env <- parent.frame()
+    tree <- build_function_tree(test_env, where, where_name)
+    fake_through_tree(tree, what, how)
+  }
+})

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -67,3 +67,14 @@ fix_mtime <- function(x) {
     x
   )
 }
+
+set_user_in_url <- function(url, username = "username", password = NULL) {
+  psd <- parse_url(url)
+  paste0(psd$protocol, "://",
+    username,
+    if (!is.null(password)) paste0(":", password),
+    "@",
+    psd$host,
+    psd$path
+  )
+}

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -47,39 +47,33 @@ test_that("looking up auth headers for repositories works as expected", {
 test_that("basic auth credentials can be extracted from various URL formats", {
   expect_equal(
     extract_basic_auth_credentials("https://user.name:pass-word123@example.com"),
-    list(username = "user.name", password = "pass-word123")
+    list(
+      hosturl = "https://example.com",
+      repourl = "https://example.com",
+      username = "user.name",
+      password = "pass-word123"
+    )
   )
   expect_equal(
     extract_basic_auth_credentials("http://user@example.com"),
-    list(username = "user", password = NULL)
+    list(
+      hosturl = "http://example.com",
+      repourl = "http://example.com",
+      username = "user",
+      password = ""
+    )
   )
   expect_equal(
     extract_basic_auth_credentials("https://example.com"),
-    list(username = NULL, password = NULL)
+    list(
+      hosturl = "https://example.com",
+      repourl = "https://example.com",
+      username = "",
+      password = ""
+    )
   )
   expect_error(
     extract_basic_auth_credentials("notaurl"),
     "Unrecognized URL format"
-  )
-})
-
-test_that("we can extract hostnames and repository URLs from package URLs", {
-  expect_equal(
-    extract_repo_url(
-      "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz"
-    ),
-    "https://ppm.internal/cran/latest"
-  )
-  expect_equal(
-    extract_repo_url(
-      "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/pkg.tar.gz"
-    ),
-    "https://ppm.internal/cran/latest"
-  )
-  expect_equal(
-    extract_hostname(
-      "https://username@ppm.internal/cran/latest/__linux__/jammy/src/contrib/PACKAGES.gz"
-    ),
-    "https://ppm.internal"
   )
 })

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -26,7 +26,10 @@ test_that("looking up auth headers for repositories works as expected", {
         "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
         allow_prompt = FALSE
       ),
-      c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4=")
+      list(
+        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+        auth_domain = "https://ppm.internal/cran/latest"
+      )
     )
   )
 
@@ -39,7 +42,10 @@ test_that("looking up auth headers for repositories works as expected", {
         "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
         allow_prompt = FALSE
       ),
-      c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4=")
+      list(
+        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+        auth_domain = "https://ppm.internal"
+      )
     )
   )
 })

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -2,19 +2,27 @@ test_that("looking up auth headers for repositories works as expected", {
   skip_if_not_installed("keyring")
 
   # No package directory in the URL.
-  expect_null(repo_auth_headers("https://username@ppm.internal/healthz"))
+  expect_null(repo_auth_headers(
+    "https://username@ppm.internal/healthz",
+    use_cache = FALSE,
+    set_cache = FALSE
+  ))
 
   # The URL already contains a password.
   expect_null(
     repo_auth_headers(
-      "https://username:password@ppm.internal/cran/latest/src/contrib/PACKAGES.gz"
+      "https://username:password@ppm.internal/cran/latest/src/contrib/PACKAGES.gz",
+      use_cache = FALSE,
+      set_cache = FALSE
     )
   )
 
   # No username in the repo URL.
   expect_null(
     repo_auth_headers(
-      "https://ppm.internal/cran/latest/src/contrib/PACKAGES.gz"
+      "https://ppm.internal/cran/latest/src/contrib/PACKAGES.gz",
+      use_cache = FALSE,
+      set_cache = FALSE
     )
   )
 

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -24,7 +24,9 @@ test_that("looking up auth headers for repositories works as expected", {
     expect_equal(
       repo_auth_headers(
         "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
-        allow_prompt = FALSE
+        allow_prompt = FALSE,
+        use_cache = FALSE,
+        set_cache = FALSE
       ),
       list(
         headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
@@ -40,7 +42,9 @@ test_that("looking up auth headers for repositories works as expected", {
     expect_equal(
       repo_auth_headers(
         "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
-        allow_prompt = FALSE
+        allow_prompt = FALSE,
+        use_cache = FALSE,
+        set_cache = FALSE
       ),
       list(
         headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,0 +1,85 @@
+test_that("looking up auth headers for repositories works as expected", {
+  skip_if_not_installed("keyring")
+
+  # No package directory in the URL.
+  expect_null(repo_auth_headers("https://username@ppm.internal/healthz"))
+
+  # The URL already contains a password.
+  expect_null(
+    repo_auth_headers(
+      "https://username:password@ppm.internal/cran/latest/src/contrib/PACKAGES.gz"
+    )
+  )
+
+  # No username in the repo URL.
+  expect_null(
+    repo_auth_headers(
+      "https://ppm.internal/cran/latest/src/contrib/PACKAGES.gz"
+    )
+  )
+
+  # Verify that the environment variable keyring backend is picked up correctly.
+  withr::with_envvar(
+    c("https://ppm.internal/cran/latest:username" = "token"),
+    expect_equal(
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+        allow_prompt = FALSE
+      ),
+      c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4=")
+    )
+  )
+
+  # Verify that we fall back to checking for a hostname credential when none
+  # is available for a specific repo.
+  withr::with_envvar(
+    c("https://ppm.internal:username" = "token"),
+    expect_equal(
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+        allow_prompt = FALSE
+      ),
+      c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4=")
+    )
+  )
+})
+
+test_that("basic auth credentials can be extracted from various URL formats", {
+  expect_equal(
+    extract_basic_auth_credentials("https://user.name:pass-word123@example.com"),
+    list(username = "user.name", password = "pass-word123")
+  )
+  expect_equal(
+    extract_basic_auth_credentials("http://user@example.com"),
+    list(username = "user", password = NULL)
+  )
+  expect_equal(
+    extract_basic_auth_credentials("https://example.com"),
+    list(username = NULL, password = NULL)
+  )
+  expect_error(
+    extract_basic_auth_credentials("notaurl"),
+    "Unrecognized URL format"
+  )
+})
+
+test_that("we can extract hostnames and repository URLs from package URLs", {
+  expect_equal(
+    extract_repo_url(
+      "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz"
+    ),
+    "https://ppm.internal/cran/latest"
+  )
+  expect_equal(
+    extract_repo_url(
+      "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/pkg.tar.gz"
+    ),
+    "https://ppm.internal/cran/latest"
+  )
+  expect_equal(
+    extract_hostname(
+      "https://username@ppm.internal/cran/latest/__linux__/jammy/src/contrib/PACKAGES.gz"
+    ),
+    "https://ppm.internal"
+  )
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -27,37 +27,25 @@ test_that("looking up auth headers for repositories works as expected", {
   )
 
   # Verify that the environment variable keyring backend is picked up correctly.
-  withr::with_envvar(
-    c("https://ppm.internal/cran/latest:username" = "token"),
-    expect_equal(
-      repo_auth_headers(
-        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
-        allow_prompt = FALSE,
-        use_cache = FALSE,
-        set_cache = FALSE
-      ),
-      list(
-        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-        auth_domain = "https://ppm.internal/cran/latest"
-      )
+  withr::local_envvar(c("https://ppm.internal/cran/latest:username" = "token"))
+  expect_snapshot(
+    repo_auth_headers(
+      "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+      allow_prompt = FALSE,
+      use_cache = FALSE,
+      set_cache = FALSE
     )
   )
 
   # Verify that we fall back to checking for a hostname credential when none
   # is available for a specific repo.
-  withr::with_envvar(
-    c("https://ppm.internal:username" = "token"),
-    expect_equal(
-      repo_auth_headers(
-        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
-        allow_prompt = FALSE,
-        use_cache = FALSE,
-        set_cache = FALSE
-      ),
-      list(
-        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-        auth_domain = "https://ppm.internal"
-      )
+  withr::local_envvar(c("https://ppm.internal:username" = "token"))
+  expect_snapshot(
+    repo_auth_headers(
+      "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+      allow_prompt = FALSE,
+      use_cache = FALSE,
+      set_cache = FALSE
     )
   )
 })
@@ -66,90 +54,40 @@ test_that("caching", {
   on.exit(clear_auth_cache(), add = TRUE)
 
   clear_auth_cache()
-  withr::with_envvar(
-    c("https://ppm.internal/cran/latest:username" = "token"),
-    expect_equal(
-      repo_auth_headers(
-        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
-        allow_prompt = FALSE,
-        use_cache = TRUE,
-        set_cache = TRUE
-      ),
-      list(
-        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-        auth_domain = "https://ppm.internal/cran/latest"
-      )
+  withr::local_envvar(c("https://ppm.internal/cran/latest:username" = "token"))
+  expect_snapshot({
+    repo_auth_headers(
+      "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+      allow_prompt = FALSE,
+      use_cache = TRUE,
+      set_cache = TRUE
     )
-  )
-  expect_equal(
-    pkgenv$credentials[["https://ppm.internal/cran/latest"]],
-    list(
-      headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-      auth_domain = "https://ppm.internal/cran/latest"
-    )
-  )
+    pkgenv$credentials[["https://ppm.internal/cran/latest"]]
+  })
 
   clear_auth_cache()
-  withr::with_envvar(
-    c("https://ppm.internal:username" = "token"),
-    expect_equal(
-      repo_auth_headers(
-        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
-        allow_prompt = FALSE,
-        use_cache = TRUE,
-        set_cache = TRUE
-      ),
-      list(
-        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-        auth_domain = "https://ppm.internal"
-      )
+  withr::local_envvar(c(
+    "https://ppm.internal:username" = "token",
+    "https://ppm.internal/cran/latest:username" = NA_character_
+  ))
+  expect_snapshot({
+    repo_auth_headers(
+      "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+      allow_prompt = FALSE,
+      use_cache = TRUE,
+      set_cache = TRUE
     )
-  )
-  expect_equal(
-    pkgenv$credentials[["https://ppm.internal"]],
-    list(
-      headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
-      auth_domain = "https://ppm.internal"
-    )
-  )
+    pkgenv$credentials[["https://ppm.internal"]]
+  })
 })
 
 test_that("basic auth credentials can be extracted from various URL formats", {
-  expect_equal(
-    extract_basic_auth_credentials("https://user.name:pass-word123@example.com"),
-    list(
-      hosturl = "https://example.com",
-      hostuserurl = "https://user.name@example.com",
-      repourl = "https://example.com",
-      repouserurl = "https://user.name@example.com",
-      username = "user.name",
-      password = "pass-word123"
-    )
-  )
-  expect_equal(
-    extract_basic_auth_credentials("http://user@example.com"),
-    list(
-      hosturl = "http://example.com",
-      hostuserurl = "http://user@example.com",
-      repourl = "http://example.com",
-      repouserurl = "http://user@example.com",
-      username = "user",
-      password = ""
-    )
-  )
-  expect_equal(
-    extract_basic_auth_credentials("https://example.com"),
-    list(
-      hosturl = "https://example.com",
-      hostuserurl = "https://example.com",
-      repourl = "https://example.com",
-      repouserurl = "https://example.com",
-      username = "",
-      password = ""
-    )
-  )
-  expect_error(
-    extract_basic_auth_credentials("notaurl"),
-    "Unrecognized URL format"
-  )
+  expect_snapshot({
+    extract_basic_auth_credentials("https://user.name:pass-word123@example.com")
+    extract_basic_auth_credentials("http://user@example.com")
+    extract_basic_auth_credentials("https://example.com")
+  })
+  expect_snapshot(error = TRUE, {
+    extract_basic_auth_credentials("notaurl")
+  })
 })

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -62,12 +62,66 @@ test_that("looking up auth headers for repositories works as expected", {
   )
 })
 
+test_that("caching", {
+  on.exit(clear_auth_cache(), add = TRUE)
+
+  clear_auth_cache()
+  withr::with_envvar(
+    c("https://ppm.internal/cran/latest:username" = "token"),
+    expect_equal(
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/__linux__/jammy/latest/src/contrib/PACKAGES.gz",
+        allow_prompt = FALSE,
+        use_cache = TRUE,
+        set_cache = TRUE
+      ),
+      list(
+        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+        auth_domain = "https://ppm.internal/cran/latest"
+      )
+    )
+  )
+  expect_equal(
+    pkgenv$credentials[["https://ppm.internal/cran/latest"]],
+    list(
+      headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+      auth_domain = "https://ppm.internal/cran/latest"
+    )
+  )
+
+  clear_auth_cache()
+  withr::with_envvar(
+    c("https://ppm.internal:username" = "token"),
+    expect_equal(
+      repo_auth_headers(
+        "https://username@ppm.internal/cran/latest/bin/linux/4.4-jammy/contrib/4.4/PACKAGES.gz",
+        allow_prompt = FALSE,
+        use_cache = TRUE,
+        set_cache = TRUE
+      ),
+      list(
+        headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+        auth_domain = "https://ppm.internal"
+      )
+    )
+  )
+  expect_equal(
+    pkgenv$credentials[["https://ppm.internal"]],
+    list(
+      headers = c("Authorization" = "Basic dXNlcm5hbWU6dG9rZW4="),
+      auth_domain = "https://ppm.internal"
+    )
+  )
+})
+
 test_that("basic auth credentials can be extracted from various URL formats", {
   expect_equal(
     extract_basic_auth_credentials("https://user.name:pass-word123@example.com"),
     list(
       hosturl = "https://example.com",
+      hostuserurl = "https://user.name@example.com",
       repourl = "https://example.com",
+      repouserurl = "https://user.name@example.com",
       username = "user.name",
       password = "pass-word123"
     )
@@ -76,7 +130,9 @@ test_that("basic auth credentials can be extracted from various URL formats", {
     extract_basic_auth_credentials("http://user@example.com"),
     list(
       hosturl = "http://example.com",
+      hostuserurl = "http://user@example.com",
       repourl = "http://example.com",
+      repouserurl = "http://user@example.com",
       username = "user",
       password = ""
     )
@@ -85,7 +141,9 @@ test_that("basic auth credentials can be extracted from various URL formats", {
     extract_basic_auth_credentials("https://example.com"),
     list(
       hosturl = "https://example.com",
+      hostuserurl = "https://example.com",
       repourl = "https://example.com",
+      repouserurl = "https://example.com",
       username = "",
       password = ""
     )

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -139,7 +139,11 @@ test_that("http requests with auth", {
 })
 
 test_that("repo with basic auth", {
-  withr::local_options(keyring_backend = "env")
+  withr::local_options(
+    keyring_backend = "env",
+    cli.dynamic = FALSE,
+    cli.ansi = FALSE
+  )
 
   fake_cran_auth <- webfakes::local_app_process(
     cran_app(


### PR DESCRIPTION
This commit updates both the metadata and package caches to support downloading packages and package indexes from repositories that require HTTP basic authentication to access.

Initial support for these authenticated repositories is very narrow: the repository URL must contain a username, no password, and have an entry in the system keyring. We also don't make any attempt to prompt users for credentials when requests fail.

Unit tests are included for the new authentication header helpers, but there are currently no tests of end-to-end workflows with an authenticated repository, and I may have missed something.

Part of r-lib/pak#729.