### PR TITLE
fix regex to detect manylinux as ppm binary repo

### DIFF
--- a/R/metadata-cache.R
+++ b/R/metadata-cache.R
@@ -602,7 +602,7 @@ re_ppm_linux <- function() {
     "(?<base>.*/)",
     "(?<repo>[^/]+)/",
     "__linux__/",
-    "(?<distro>[a-zA-Z0-9]+)/",
+    "(?<distro>[a-zA-Z0-9_]+)/",
     "(?<version>latest|[-0-9]+)",
     "$"
   )


### PR DESCRIPTION
This pull request fixes the issues [#883](https://github.com/r-lib/pak/issues/883) in `pak`  and [#183](https://github.com/r-lib/pkgcache/issues/138). The problem is that `pkgcache:::is_ppm_linux_repo_url()` does not recognize manylinux as a binary download url. 